### PR TITLE
add a since filter

### DIFF
--- a/pkg/clients/pagerduty.go
+++ b/pkg/clients/pagerduty.go
@@ -102,6 +102,8 @@ func (c *PagerdutyClient) GetUserByEmail(email string) (*pagerduty.User, error) 
 func (c *PagerdutyClient) ListIncidents(f *Filter) ([]pagerduty.Incident, error) {
 	o := pagerduty.ListIncidentsOptions{
 		Statuses: []string{IncidentStatusTriggered, IncidentStatusAcknowledged},
+		Since: time.Now().AddDate(0,0,-1).Format(time.RFC3339),
+		SortBy: "created_at:desc",
 	}
 
 	if f != nil {


### PR DESCRIPTION
needed to migration to other pd instance delivering too many old items. this is a interims solution - better filter on services